### PR TITLE
FLF: Add json interop tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,15 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    reviewers:
-      - "hfhbd"
     assignees:
       - "hfhbd"
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
       interval: "daily"
-    reviewers:
-      - "hfhbd"
     assignees:
       - "hfhbd"

--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: docs
+      - run: find . \! -name CNAME -delete
       - uses: actions/download-artifact@v3
       - name: Copy files to /
         run: cp -r artifact/* . && rm -Rf artifact/*

--- a/kotlinx-serialization-csv/build.gradle.kts
+++ b/kotlinx-serialization-csv/build.gradle.kts
@@ -36,21 +36,16 @@ kotlin {
     mingwX86()
 
     sourceSets {
+        val serialization = "1.3.3"
         commonMain {
             dependencies {
-                api("org.jetbrains.kotlinx:kotlinx-serialization-core:1.3.3")
+                api("org.jetbrains.kotlinx:kotlinx-serialization-core:$serialization")
             }
         }
         commonTest {
             dependencies {
                 implementation(kotlin("test"))
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.3.3")
-            }
-        }
-
-        val jvmTest by getting {
-            dependencies {
-                implementation(kotlin("test-junit"))
             }
         }
     }

--- a/kotlinx-serialization-flf/build.gradle.kts
+++ b/kotlinx-serialization-flf/build.gradle.kts
@@ -36,21 +36,17 @@ kotlin {
     mingwX86()
 
     sourceSets {
+        val serialization = "1.3.3"
         commonMain {
             dependencies {
-                api("org.jetbrains.kotlinx:kotlinx-serialization-core:1.3.3")
+                api("org.jetbrains.kotlinx:kotlinx-serialization-core:$serialization")
             }
         }
         commonTest {
             dependencies {
                 implementation(kotlin("test"))
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.3.3")
-            }
-        }
-
-        val jvmTest by getting {
-            dependencies {
-                implementation(kotlin("test-junit"))
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$serialization")
             }
         }
     }

--- a/kotlinx-serialization-flf/src/commonTest/kotlin/app/softwork/serialization/flf/FlfDecoderTest.kt
+++ b/kotlinx-serialization-flf/src/commonTest/kotlin/app/softwork/serialization/flf/FlfDecoderTest.kt
@@ -15,31 +15,7 @@ class FlfDecoderTest {
         """.trimIndent()
 
         assertEquals(
-            expected = Sample(
-                shortString = "Short",
-                longString = "Long",
-                int = 42,
-                double = 42.3,
-                nil = null,
-                date = Instant.fromEpochSeconds(0L),
-                enum = Sample.Testing.Two,
-                inline = Sample.Foo(1),
-                inlineS = Sample.FooS("foo"),
-                inlineD = Sample.FooD(4.0),
-                inlineB = Sample.FooB(true),
-                inlineL = Sample.FooL(0L),
-                inlineChar = Sample.FooChar('f'),
-                inlineShort = Sample.FooShort(4.toShort()),
-                inlineFloat = Sample.FooFloat(1f),
-                inlineByte = Sample.FooByte(1.toByte()),
-                innerClass = Sample.Inner(8),
-                boolean = false,
-                byte = 1.toByte(),
-                short = 1.toShort(),
-                float = 4.0f,
-                long = -1L,
-                char = ' '
-            ),
+            expected = Sample.sample,
             actual = FixedLengthFormat.decodeFromString(Sample.serializer(), flf)
         )
     }

--- a/kotlinx-serialization-flf/src/commonTest/kotlin/app/softwork/serialization/flf/FlfDecoderTest.kt
+++ b/kotlinx-serialization-flf/src/commonTest/kotlin/app/softwork/serialization/flf/FlfDecoderTest.kt
@@ -15,7 +15,7 @@ class FlfDecoderTest {
         """.trimIndent()
 
         assertEquals(
-            expected = Sample.sample,
+            expected = Sample.simple,
             actual = FixedLengthFormat.decodeFromString(Sample.serializer(), flf)
         )
     }

--- a/kotlinx-serialization-flf/src/commonTest/kotlin/app/softwork/serialization/flf/FlfDecoderTest.kt
+++ b/kotlinx-serialization-flf/src/commonTest/kotlin/app/softwork/serialization/flf/FlfDecoderTest.kt
@@ -11,7 +11,7 @@ class FlfDecoderTest {
     @Test
     fun normal() {
         val flf = """
-            ShortLong      42  42.3    1970-01-01T00:00:00ZTwo  1  foo4.0true0  f41.018false1   1   4.0 -1   
+            ShortLong      42  42.3    1970-01-01T00:00:00ZTwo  1  foo4.2true0  f41.118false1   1   4.2 -1   
         """.trimIndent()
 
         assertEquals(

--- a/kotlinx-serialization-flf/src/commonTest/kotlin/app/softwork/serialization/flf/FlfEncoderTest.kt
+++ b/kotlinx-serialization-flf/src/commonTest/kotlin/app/softwork/serialization/flf/FlfEncoderTest.kt
@@ -12,31 +12,7 @@ class FlfEncoderTest {
     fun normal() {
         val flf = FixedLengthFormat.encodeToString(
             serializer = Sample.serializer(),
-            value = Sample(
-                shortString = "Short",
-                longString = "Long",
-                int = 42,
-                double = 42.3,
-                nil = null,
-                date = Instant.fromEpochSeconds(0L),
-                enum = Sample.Testing.Two,
-                inline = Sample.Foo(1),
-                inlineS = Sample.FooS("foo"),
-                inlineD = Sample.FooD(4.2),
-                inlineB = Sample.FooB(true),
-                inlineL = Sample.FooL(0L),
-                inlineChar = Sample.FooChar('f'),
-                inlineShort = Sample.FooShort(4.toShort()),
-                inlineFloat = Sample.FooFloat(1.1f),
-                inlineByte = Sample.FooByte(1.toByte()),
-                innerClass = Sample.Inner(8),
-                boolean = false,
-                byte = 1.toByte(),
-                short = 1.toShort(),
-                float = 4.2f,
-                long = -1L,
-                char = ' '
-            )
+            value = Sample.sample
         )
         assertEquals(
             expected = """

--- a/kotlinx-serialization-flf/src/commonTest/kotlin/app/softwork/serialization/flf/FlfEncoderTest.kt
+++ b/kotlinx-serialization-flf/src/commonTest/kotlin/app/softwork/serialization/flf/FlfEncoderTest.kt
@@ -12,7 +12,7 @@ class FlfEncoderTest {
     fun normal() {
         val flf = FixedLengthFormat.encodeToString(
             serializer = Sample.serializer(),
-            value = Sample.sample
+            value = Sample.simple
         )
         assertEquals(
             expected = """

--- a/kotlinx-serialization-flf/src/commonTest/kotlin/app/softwork/serialization/flf/JsonTest.kt
+++ b/kotlinx-serialization-flf/src/commonTest/kotlin/app/softwork/serialization/flf/JsonTest.kt
@@ -9,14 +9,14 @@ class JsonTest {
     @Test
     fun interop() {
         val sampleFlf = """
-                ShortLong      42  42.3    1970-01-01T00:00:00ZTwo  1  foo4.2true0  f41.118false1   1   4.2 -1   
-            """.trimIndent()
+        ShortLong      42  42.3    1970-01-01T00:00:00ZTwo  1  foo4.2true0  f41.118false1   1   4.2 -1   
+        """.trimIndent()
         val decode = FixedLengthFormat.decodeFromString(
             deserializer = Sample.serializer(),
             string = sampleFlf
         )
         assertEquals(
-            Sample.sample,
+            Sample.simple,
             decode
         )
         val jsonString = Json { prettyPrint = true }.encodeToString(Sample.serializer(), decode)
@@ -55,7 +55,7 @@ class JsonTest {
         )
         val sampleJson = Json.decodeFromString(Sample.serializer(), jsonString)
         assertEquals(
-            Sample.sample,
+            Sample.simple,
             sampleJson
         )
         val flfString = FixedLengthFormat.encodeToString(

--- a/kotlinx-serialization-flf/src/commonTest/kotlin/app/softwork/serialization/flf/JsonTest.kt
+++ b/kotlinx-serialization-flf/src/commonTest/kotlin/app/softwork/serialization/flf/JsonTest.kt
@@ -1,0 +1,70 @@
+package app.softwork.serialization.flf
+
+import kotlinx.serialization.*
+import kotlinx.serialization.json.*
+import kotlin.test.*
+
+@ExperimentalSerializationApi
+class JsonTest {
+    @Test
+    fun interop() {
+        val sampleFlf = """
+                ShortLong      42  42.3    1970-01-01T00:00:00ZTwo  1  foo4.2true0  f41.118false1   1   4.2 -1   
+            """.trimIndent()
+        val decode = FixedLengthFormat.decodeFromString(
+            deserializer = Sample.serializer(),
+            string = sampleFlf
+        )
+        assertEquals(
+            Sample.sample,
+            decode
+        )
+        val jsonString = Json { prettyPrint = true }.encodeToString(Sample.serializer(), decode)
+        //language=JSON
+        assertEquals(
+            """
+            {
+                "shortString": "Short",
+                "longString": "Long",
+                "int": 42,
+                "double": 42.3,
+                "nil": null,
+                "date": "1970-01-01T00:00:00Z",
+                "enum": "Two",
+                "inline": 1,
+                "inlineS": "foo",
+                "inlineD": 4.2,
+                "inlineB": true,
+                "inlineL": 0,
+                "inlineChar": "f",
+                "inlineShort": 4,
+                "inlineFloat": 1.1,
+                "inlineByte": 1,
+                "innerClass": {
+                    "s": 8
+                },
+                "boolean": false,
+                "byte": 1,
+                "short": 1,
+                "float": 4.2,
+                "long": -1,
+                "char": " "
+            }
+            """.trimIndent(),
+            jsonString
+        )
+        val sampleJson = Json.decodeFromString(Sample.serializer(), jsonString)
+        assertEquals(
+            Sample.sample,
+            sampleJson
+        )
+        val flfString = FixedLengthFormat.encodeToString(
+            serializer = Sample.serializer(),
+            value = sampleJson
+        )
+        assertEquals(
+            sampleFlf,
+            flfString
+        )
+    }
+}

--- a/kotlinx-serialization-flf/src/commonTest/kotlin/app/softwork/serialization/flf/Sample.kt
+++ b/kotlinx-serialization-flf/src/commonTest/kotlin/app/softwork/serialization/flf/Sample.kt
@@ -32,6 +32,34 @@ data class Sample(
     @FixedLength(4) val long: Long,
     @FixedLength(1) val char: Char
 ) {
+    companion object {
+        val sample = Sample(
+            shortString = "Short",
+            longString = "Long",
+            int = 42,
+            double = 42.3,
+            nil = null,
+            date = Instant.fromEpochSeconds(0L),
+            enum = Sample.Testing.Two,
+            inline = Foo(1),
+            inlineS = FooS("foo"),
+            inlineD = FooD(4.2),
+            inlineB = FooB(true),
+            inlineL = FooL(0L),
+            inlineChar = FooChar('f'),
+            inlineShort = FooShort(4.toShort()),
+            inlineFloat = FooFloat(1.1f),
+            inlineByte = FooByte(1.toByte()),
+            innerClass = Inner(8),
+            boolean = false,
+            byte = 1.toByte(),
+            short = 1.toShort(),
+            float = 4.2f,
+            long = -1L,
+            char = ' '
+        )
+    }
+
     @Serializable
     enum class Testing {
         One, Two, Three

--- a/kotlinx-serialization-flf/src/commonTest/kotlin/app/softwork/serialization/flf/Sample.kt
+++ b/kotlinx-serialization-flf/src/commonTest/kotlin/app/softwork/serialization/flf/Sample.kt
@@ -33,7 +33,7 @@ data class Sample(
     @FixedLength(1) val char: Char
 ) {
     companion object {
-        val sample = Sample(
+        val simple = Sample(
             shortString = "Short",
             longString = "Long",
             int = 42,


### PR DESCRIPTION
We use custom annotations, which should be ignored with Json. 